### PR TITLE
Use version tags for the current container image release

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,14 +284,29 @@ If you haven't configured Docker for GCP container registry, run the following:
 gcloud auth configure-docker
 ```
 
+Now, choose a release candidate version for the new image. The version should be
+of the form `YYYY_MM_DDrcVV` where `VV` is used for multiple versions per day
+(start with 00).
 
 ```
-docker tag jserver:latest gcr.io/rhodes-cs/jserver
+export RC_VERSION=YYYY_MM_DDrcVV
+docker tag jserver:latest gcr.io/rhodes-cs/jserver:$RC_VERSION
 docker image ls
-docker push gcr.io/rhodes-cs/jserver
+docker push gcr.io/rhodes-cs/jserver:$RC_VERSION
 ```
 
 Now you should see the container when you run `gcloud container images list`.
+Additionally, you should see the the new release candidate tag when you run
+`gcloud container images list-tags gcr.io/rhodes-cs/jserver`:
+
+```
+gcloud container images list-tags gcr.io/rhodes-cs/jserver
+DIGEST        TAGS                   TIMESTAMP
+48d50b385e28  2020_02_16rc01,latest  2021-02-16T15:54:46
+fde1b612abad                         2021-02-14T18:06:17
+e05babc291c6                         2021-01-24T21:32:16
+6d4d44ff86d5                         2020-12-19T18:13:00
+```
 
 # Troubleshooting and Administration
 

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -15,8 +15,9 @@ singleuser:
   image:
     # Configured for Rhodes with required libraries installed.
     name: gcr.io/rhodes-cs/jserver
-    # May want to settle on a stable version and allow development branches.
-    tag: latest
+    # When upgrading the docker image, update the tag.
+    # Tags should be in the namespace YYYY_MM_DDrcVV
+    tag: 2020_02_16rc01
   # user resource limits
   memory:
     limit: 1G


### PR DESCRIPTION
This forces the pre-puller to grab new images as soon as they are pushed and the helm config is pushed.

I tried to make a pre-commit check to validate that CLs with changes to the Dockerfile flag the config file to also be changed, but those sorts of hooks are weird to get into version control. I'll set up some sort of hook on the github side.